### PR TITLE
Bump version to 3.6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = resc_vcs_scanner
 description = Repository Scanner - Version Control System - Scanner
-version = 3.5.1
+version = 3.6.0
 author = ABN AMRO
 author_email = resc@nl.abnamro.com
 url = https://github.com/ABNAMRO/repository-scanner


### PR DESCRIPTION
I did not bump the vcs scanner version when merging into main. This PR will bump version properly. 